### PR TITLE
Attribution of the theme in footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # see https://github.com/ELIXIR-Belgium/elixir-toolkit-theme
 title: "How-to-Guides"
 description: A collection of bioinformatics focused How-to-Guides
-remote_theme: ELIXIR-Belgium/jekyll-bootstrap-theme@1.20.2
+remote_theme: ELIXIR-Belgium/jekyll-bootstrap-theme@1.23.0
 topnav_title: How-to-Guides
 gtag: G-T8GWK081T9
 

--- a/_sass/_bootstrap_variables.scss
+++ b/_sass/_bootstrap_variables.scss
@@ -21,6 +21,5 @@ $dark:          #212529;
 
 /*-----Custom values for Bootstrap variables-----*/
 $link-decoration: none;
-$nav-link-color: $dark;
-$nav-link-hover-color: $primary;
+$navbar-light-hover-color: $primary;
 $link-color: $blue;


### PR DESCRIPTION
hey @supernord. Since not so long ago, we started to have a 'Built with ETT' batch in the footer of the theme to introduce a recognizable branding. The added support for the latest bootstrap and many other improvements are off course also included.

![Screenshot from 2023-02-02 17-47-28](https://user-images.githubusercontent.com/44875756/216391062-549b309c-c11b-42c2-a97b-5ef82bef7077.png)

Thanks in advance if you would be ok with it!